### PR TITLE
Fix CLI package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "opent2t",
-    "version": "1.0.0",
+    "name": "opent2t-cli",
+    "version": "0.1.0",
     "description": "Command Line Interface (CLI) for Open Translators to Things.",
     "bin": {
         "opent2t": "./index.js"


### PR DESCRIPTION
This fixes https://github.com/openT2T/cli/issues/1

Apparently [we'll have to contact npm support](http://blog.npmjs.org/post/141905368000/changes-to-npms-unpublish-policy) in order to unpublish the wrongly-named package; I haven't done that yet.
