### PR TITLE
Translator packaging script

### DIFF
--- a/pack-translator.js
+++ b/pack-translator.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+var fs = require("fs");
+var path = require("path");
+var program = require('commander');
+
+var LocalPackageSource = require("opent2t/package/LocalPackageSource").LocalPackageSource;
+
+program
+    .version("0.1.0")
+    .usage("<translator name>")
+    .parse(process.argv);
+
+if (program.args.length != 1) {
+    program.outputHelp();
+} else {
+    packTranslator(program.args[0]);
+}
+
+function packTranslator(name) {
+    var translatorPackageName = "opent2t-translator-" + name.replace(/\./g, "-");
+
+    var packageSource = new LocalPackageSource(".");
+    packageSource.getPackageInfoAsync(translatorPackageName).then(function (packageInfo) {
+        if (!packageInfo) {
+            console.error("Package not found. " +
+                    "Make sure the current directory is the root of the translators repo.");
+            return;
+        }
+
+        var packageTranslatorInfo = packageInfo.translators[0];
+        var packageJsonPath = packageTranslatorInfo.moduleName.replace("/thingTranslator", "/package.json");
+        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+        LocalPackageSource.mergePackageInfo(packageJson, packageInfo);
+
+        packageJson.main = packageTranslatorInfo.moduleName;
+
+        var schemaName = packageTranslatorInfo.moduleName.split("/")[0];
+        var translatorName = packageTranslatorInfo.moduleName.split("/")[1];
+        packageJson.files = [
+            schemaName + "/*.raml",
+            schemaName + "/*.xml",
+            schemaName + "/*.json",
+            schemaName + "/*.js",
+            schemaName + "/" + translatorName
+        ];
+
+        fs.writeFileSync("package.json", JSON.stringify(packageJson, null, 2), "utf8");
+        console.log("Generated ./package.json file for " + packageJson.name + ".\n" +
+                "Ready for npm pack or npm publish.");
+
+    }).catch (function (error) {
+        console.error("Failed to load package info: " + error);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "opent2t",
-    "version": "1.0.0",
+    "name": "opent2t-cli",
+    "version": "0.1.0",
     "description": "Command Line Interface (CLI) for Open Translators to Things.",
     "bin": {
         "opent2t": "./index.js"

--- a/package.json
+++ b/package.json
@@ -1,26 +1,27 @@
 {
-    "name": "opent2t-cli",
-    "version": "0.1.0",
-    "description": "Command Line Interface (CLI) for Open Translators to Things.",
-    "bin": {
-        "opent2t": "./index.js"
-    },
-    "dependencies": {
-        "commander": "^2.9.0",
-        "colors": "^1.1.2"
-    },
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "preferGlobal": true,
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/openT2T/cli.git"
-    },
-    "author": "Open Translators to Things",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/openT2T/cli/issues"
-    },
-    "homepage": "https://github.com/openT2T/cli#readme"
+  "name": "opent2t-cli",
+  "version": "0.1.0",
+  "description": "Command Line Interface (CLI) for Open Translators to Things.",
+  "bin": {
+    "opent2t": "./index.js"
+  },
+  "dependencies": {
+    "colors": "^1.1.2",
+    "commander": "^2.9.0",
+    "opent2t": "^0.1.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "preferGlobal": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openT2T/cli.git"
+  },
+  "author": "Open Translators to Things",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/openT2T/cli/issues"
+  },
+  "homepage": "https://github.com/openT2T/cli#readme"
 }


### PR DESCRIPTION
Fixes https://github.com/openT2T/translators/issues/51
Depends on https://github.com/openT2T/opent2t/pull/20

This is a quick and dirty script to generate a `package.json` suitable for packing/publishing a translator package to NPM with a following `npm publish` command. The script definitely needs more work to make it robust and user-friendly, but it's a start.

The most important piece of functionality that is missing is to be able to detect referenced schemas and also include those schema files by adding them to the `"files"` property in `package.json`. That's not an issue for translators that implement AllJoyn schemas (because AllJoyn schemas don't reference other schemas), but it is for OCF. Since this script only generates the `package.json` file and leaves it there, one could hand-modify it to add additional schema directories before publishing. I'll make that automatic later.

(Someone should add `/package.json` to `.gitignore` in the translators repo. But I didn't think that was worth a PR on its own.)
