### PR TITLE
Adding RefreshToken support to opent2t-cli for testing RefreshAuthToken() workflow

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -63,7 +63,6 @@ function logError(error) {
     }
 }
 
-
 function createHubDeviceFileName(hubName, deviceId) {
     return createSaveFileName(hubName, "_device_" + deviceId);
 }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ program
     .version('1.0.0')
     .option('-o --onboarding [Translator Package Name]', 'Do onboarding for specified thing')
     .option('-h --hub [Hub Package Name]', 'Gets devices for the given hub')
+    .option('-r --refreshAuthToken [Translator Package Name]', 'Refresh the oauth token for the given hub')
     
     .option('-t --translator [Translator Package Name]', 'Do get property for specified thing, requires -p')
     .option('-i --id [Control id]', 'Control id you want to use')
@@ -43,7 +44,7 @@ if (program.onboarding) {
     onboardingCli.doOnboarding(program.onboarding).then(info => {
         var data = JSON.stringify(info);
         helpers.logObject(info);
-        console.log("------ Saving onboaringInfo to: " + fileName); 
+        console.log("------ Saving onboardingInfo to: " + fileName); 
         fs.writeFile(fileName, data, function (err) {
             if (err) {
                 console.log(err);
@@ -121,6 +122,25 @@ else if (program.hub) {
         helpers.logError(error);
     });
 }
+else if(program.refreshAuthToken){
+    console.log("------ Refreshing oAuth token for hub %j".header, program.refreshAuthToken);
+    var onboardingCli = new OnboardingCli();
+    onboardingCli.loadTranslatorAndGetOnboardingAnswers(program.refreshAuthToken).then(answers => {
+        var fileName = helpers.createOnboardingFileName(program.refreshAuthToken);
+        helpers.readFile(fileName, "Please complete onboarding -o").then(data => { 
+        var authInfo = JSON.parse(data);
+        translatorCli.getProperty(program.refreshAuthToken, authInfo, 'refreshAuthToken', answers).then(refreshedInfo => {
+            helpers.logObject(refreshedInfo);
+            //helpers.writeArrayToFile(info.platforms, "_device_", "controlId");
+        }).catch(error => {
+            helpers.logError(error);
+        });
+    }).catch(error => {
+        helpers.logError(error);
+    });
+    });
+   
+}
 
 // this is for top level devices which don't require a hub
 else if (program.translator) {
@@ -141,6 +161,7 @@ else if (program.translator) {
         helpers.logError(error);
     });
 }
+
 else {
     program.outputHelp(make_red);
 }

--- a/index.js
+++ b/index.js
@@ -131,7 +131,16 @@ else if(program.refreshAuthToken){
         var authInfo = JSON.parse(data);
         translatorCli.getProperty(program.refreshAuthToken, authInfo, 'refreshAuthToken', answers).then(refreshedInfo => {
             helpers.logObject(refreshedInfo);
-            //helpers.writeArrayToFile(info.platforms, "_device_", "controlId");
+            console.log("------ Saving refreshed onboardingInfo to: " + fileName); 
+            var refreshedData = JSON.stringify(refreshedInfo);
+            fs.writeFile(fileName, refreshedData, function (err) {
+                if (err) {
+                    console.log(err);
+                    return console.log(err);
+                }
+            console.log("Saved!");
+        });
+
         }).catch(error => {
             helpers.logError(error);
         });

--- a/onboardingCli.js
+++ b/onboardingCli.js
@@ -38,6 +38,26 @@ class OnboardingCli {
         });
     }
 
+    loadTranslatorAndGetOnboardingAnswers(translatorName){
+        var LocalPackageSourceClass = require('opent2t/package/LocalPackageSource').LocalPackageSource;
+        var localPackageSource = new LocalPackageSourceClass("./node_modules/" + translatorName);
+
+        return localPackageSource.getAllPackageInfoAsync().then((packages) => {
+
+            // default use the first package
+            var p = packages[0];
+            if (p.translators.length > 0) {
+
+                var tinfo = p.translators[0];
+                console.log("----------------------------- Package Info");
+                helpers.logObject(tinfo);
+                console.log("-----------------------------");
+
+                return this.performFlow(tinfo.onboardingFlow);
+            }
+        });
+    }
+
     // does the onboarding flow and asks the user any input
     performFlow(onboardingFlow, i, onboardingAnswers) {
         if (!!!i) {

--- a/onboardingCli.js
+++ b/onboardingCli.js
@@ -33,11 +33,11 @@ class OnboardingCli {
                     var onboarding = new Onboarding();
                     return onboarding.onboard(answers);
                 });
-
             }
         });
     }
 
+    // loads the first package found under opent2t/package for a given translator
     loadTranslatorAndGetOnboardingAnswers(translatorName){
         var LocalPackageSourceClass = require('opent2t/package/LocalPackageSource').LocalPackageSource;
         var localPackageSource = new LocalPackageSourceClass("./node_modules/" + translatorName);
@@ -48,12 +48,16 @@ class OnboardingCli {
             var p = packages[0];
             if (p.translators.length > 0) {
 
-                var tinfo = p.translators[0];
                 console.log("----------------------------- Package Info");
                 helpers.logObject(tinfo);
                 console.log("-----------------------------");
-
-                return this.performFlow(tinfo.onboardingFlow);
+                
+                var tinfo = p.translators[0];
+                var onboardingAnswers = ['undefined'];
+                // We only require the clientId/clientSecret for Wink Hub (generalizing this right now)
+                // TODO: See how this differs with SmartThings; If radically different we'd need separate
+                // CLI implementation for WINK and SMARTTHINGS
+                return this.performFlow(tinfo.onboardingFlow, 1, onboardingAnswers);
             }
         });
     }

--- a/onboardingCli.js
+++ b/onboardingCli.js
@@ -38,6 +38,7 @@ class OnboardingCli {
     }
 
     // loads the first package found under opent2t/package for a given translator
+    // TODO: refactor doOnboarding to call into this instead to avoid code-duplication
     loadTranslatorAndGetOnboardingAnswers(translatorName){
         var LocalPackageSourceClass = require('opent2t/package/LocalPackageSource').LocalPackageSource;
         var localPackageSource = new LocalPackageSourceClass("./node_modules/" + translatorName);

--- a/translatorCli.js
+++ b/translatorCli.js
@@ -27,7 +27,7 @@ class TranslatorCli {
             return this.OpenT2T.invokeMethodAsync(translator, "", property, [deviceId, value]);
         });
     }
-
+    
     createTranslator(translatorName, deviceInfo) {
         return this.OpenT2T.createTranslatorAsync(translatorName, deviceInfo).then( translator => {
             return translator;


### PR DESCRIPTION
1. At this point, this will work only for WINK hubs; Unexpected behavior when run against any other translator/hub.
2. Overwriting the original onboarding file with the new information retrieved.
3. In the CLI it made sense to add the client calls to the onboardingcli.js though the actual implementation on the server are in teh hub translator (not onboarding module).
4. There is dup code in onboardingcli.js that I am hoping to get rid of (but had caused a break at this point when I was trying to clean it up)

**Output** (Note: You need corresponding hub changes that implement refreshAuthToken() from PR: https://github.com/openT2T/translators/pull/126) 

C:\opent2t\sj\opent2t-cli>node index.js -r opent2t-translator-com-wink-hub
Open Translators to Things CLI:

------ Refreshing oAuth token for hub "opent2t-translator-com-wink-hub"
----------------------------- Package Info
undefined
-----------------------------
--------------- "getDeveloperInput"
? Ask for Client id *****
? Ask for Client Secret *****
Getting refreshAuthToken from opent2t-translator-com-wink-hub
{
  "accessToken": "tM_pqH6Wm0-zA5Fbl5MyM5LRdV4A6z6q",
  "refreshToken": "T_i4HlCb6AkrYYwz324GO9WwgiMxRajV",
  "tokenType": "bearer",
  "scopes": "full_access"
}
------ Saving refreshed onboardingInfo to: ./opent2t-translator-com-wink-hub_onboardingInfo.json
Saved! 